### PR TITLE
Fix gitflow automation: Use tag date instead of tag name in GitHub API search

### DIFF
--- a/.github/workflows/gitflow-automation.yml
+++ b/.github/workflows/gitflow-automation.yml
@@ -92,8 +92,21 @@ jobs:
             
             let query;
             if (previousTag && previousTag !== '') {
-              // Get PRs merged since the last tag
-              query = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged merged:>=${previousTag}`;
+              // Get the date of the previous tag
+              const { data: tagData } = await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${previousTag}`
+              });
+              
+              const { data: commitData } = await github.rest.git.getCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: tagData.object.sha
+              });
+              
+              const tagDate = commitData.committer.date;
+              query = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged merged:>=${tagDate}`;
             } else {
               // Get all merged PRs (limited to 100)
               query = `repo:${context.repo.owner}/${context.repo.repo} is:pr is:merged`;


### PR DESCRIPTION
The GitHub Search API was failing because it was using version tags (e.g., 'v1.0.0')
as date filters in the merged:>= parameter. The API expects ISO 8601 date format.

Now the workflow:
1. Fetches the tag reference to get the commit SHA
2. Gets the commit data to extract the committer date
3. Uses the proper ISO 8601 date in the search query

This resolves the 422 Validation Failed error from the GitHub API.
